### PR TITLE
Add wildcard math-based DRE patch

### DIFF
--- a/64k/Compatability/DeadlyReentry_64k.cfg
+++ b/64k/Compatability/DeadlyReentry_64k.cfg
@@ -1,3 +1,49 @@
+// Wildcard patches -- NathanKell
+// These will:
+// 1. Increase the temperatures in the Loss curve to 2500/7500 instead of 1000/3000.
+// 2. Increase the loss rates by 1.5x at now-2500 shockwave temp, and 3x at 7500
+//    (so shielding loss rate will be a fair bit higher).
+// 3. Max dissipation once shield is at/above 400C, no sense having the temperature loss
+//    be lesser for the same kg of ablative ablated just because the shield is cool.
+// 4. Double reflectivity of non-ablative shielding (i.e. nosecones / spaceplane parts).
+
+@PART[*]:HAS[@MODULE[ModuleHeatShield]]:FINAL
+{
+	@maxTemp = 1800
+	@MODULE[ModuleHeatShield]
+	{
+		@loss
+		{
+			@key,1 ^= :^1000 ::
+			@key,1 ^= : 0 0::
+			@key,1 *= 1.5
+			@key,1 ^= :$: 0 0:
+			@key,1 ^= :^:2500 :
+			
+			@key,2 ^= :^3000 ::
+			@key,2 ^= : 0 0::
+			@key,2 *= 3
+			@key,2 ^= :$: 0 0:
+			@key,2 ^= :^:7500 :
+		}
+		@dissipation
+		{
+			@key,1 ^= :^500::
+			@key,1 ^= : 0 0::
+			@key,1 *= 1.5
+			@key,1 ^= :$: 0 0:
+			@key,1 ^= :^:400 :
+		}
+	}
+}
+@PART[*]:HAS[@MODULE[ModuleHeatShield]]:FINAL
+{
+	@MODULE[ModuleHeatShield]:HAS[~ablative[]]
+	{
+		@reflective *= 2.0
+	}
+}
+
 @PART[SDHI_2.5_Heatshield]:NEEDS[DeadlyReentry]:Final
 {
 	@mass = 0.061


### PR DESCRIPTION
1. Increase the temperatures in the Loss curve to 2500/7500 instead of 1000/3000.
2. Increase the loss rates by 1.5x at now-2500 shockwave temp, and 3x at 7500 (so shielding loss rate will be a fair bit higher).
3. Max dissipation once shield is at/above 400C, no sense having the temperature loss be lesser for the same kg of ablative ablated just because the shield is cool.
4. Double reflectivity of non-ablative shielding (i.e. nosecones / spaceplane parts).
